### PR TITLE
Add global error handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24758,6 +24758,21 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
+    "sourcemapped-stacktrace": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/sourcemapped-stacktrace/-/sourcemapped-stacktrace-1.1.11.tgz",
+      "integrity": "sha512-O0pcWjJqzQFVsisPlPXuNawJHHg9N9UgpJ/aDmvi9+vnS3x1C0NhwkVFzzZ1VN0Xo+bekyweoqYvBw5ZBKiNnQ==",
+      "requires": {
+        "source-map": "0.5.6"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        }
+      }
+    },
     "space-separated-tokens": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-scroll": "^1.7.10",
     "react-sound": "^1.2.0",
     "rimble-ui": "0.4.2",
+    "sourcemapped-stacktrace": "^1.1.11",
     "styled-components": "^4.1.3",
     "web3": "1.0.0-beta.36",
     "ya-bbcode": "^1.0.9"

--- a/src/App.js
+++ b/src/App.js
@@ -867,6 +867,7 @@ class App extends Component {
 
     const { voteStartTime, voteEndTime, trashBox } = this.state;
     const web3Props = { plasma: xdaiweb3, web3, account, metaAccount };
+
     return (
       <>
           {account ? (

--- a/src/App.js
+++ b/src/App.js
@@ -867,6 +867,7 @@ class App extends Component {
 
     const { voteStartTime, voteEndTime, trashBox } = this.state;
     const web3Props = { plasma: xdaiweb3, web3, account, metaAccount };
+    throw new Error("🍌");
 
     return (
       <>

--- a/src/App.js
+++ b/src/App.js
@@ -867,7 +867,6 @@ class App extends Component {
 
     const { voteStartTime, voteEndTime, trashBox } = this.state;
     const web3Props = { plasma: xdaiweb3, web3, account, metaAccount };
-    throw new Error("🍌");
 
     return (
       <>

--- a/src/components/Advanced.js
+++ b/src/components/Advanced.js
@@ -231,7 +231,7 @@ export default class Advanced extends React.Component {
         {privateKey &&
         <div>
           <div className="content ops row settings-row" >
-            <PrimaryButton onClick={() => this.props.history.push("/burn")}>              
+            <PrimaryButton onClick={() => this.props.history.push("/burn")}>
               <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
                 <i className="fas fa-fire"/> {i18n.t('burn')}
               </Scaler>

--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -29,6 +29,8 @@ export default class ErrorBoundary extends React.Component {
   }
 
   componentDidCatch(error, errorInfo) {
+    this.setState({ broken: true });
+
     mapStackTrace(error.stack, stack => {
       const message = [
         error.toString(),
@@ -42,9 +44,9 @@ export default class ErrorBoundary extends React.Component {
   }
 
   render() {
-    const { message, copied } = this.state;
+    const { broken, message, copied } = this.state;
 
-    if (message) {
+    if (broken) {
       return (
         <Container>
           <h2>Something went wrong 😢</h2>
@@ -53,19 +55,25 @@ export default class ErrorBoundary extends React.Component {
             the page, thanks!
           </p>
 
-          <Details>
-            <details>
-              <Pre>{message}</Pre>
-            </details>
-          </Details>
+          {message ? (
+            <>
+              <Details>
+                <details>
+                  <Pre>{message}</Pre>
+                </details>
+              </Details>
 
-          <CopyToClipboard
-            text={message}
-            onCopy={() => this.setState({ copied: true })}
-          >
-            <Button>Copy to clipboard</Button>
-          </CopyToClipboard>
-          {copied && <p>Copied!</p>}
+              <CopyToClipboard
+                text={message}
+                onCopy={() => this.setState({ copied: true })}
+              >
+                <Button>Copy to clipboard</Button>
+              </CopyToClipboard>
+              {copied && <p>Copied!</p>}
+            </>
+          ) : (
+            <p>Loading details, wait... ⌛</p>
+          )}
         </Container>
       );
     }

--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -1,0 +1,74 @@
+// Nice stuff here: https://reactjs.org/blog/2017/07/26/error-handling-in-react-16.html
+// Code taken from Dan Abramov's pen https://codepen.io/gaearon/pen/wqvxGa
+
+import React from "react";
+import { Box, Card, Heading, Flex, Button } from "rimble-ui";
+import styled from "styled-components";
+import { CopyToClipboard } from "react-copy-to-clipboard";
+import { mapStackTrace } from "sourcemapped-stacktrace";
+
+const Container = styled(Card)`
+  margin: 0;
+`;
+
+const Details = styled(Box).attrs(() => ({
+  mt: 0,
+  mb: 4,
+  fontSize: 2
+}))``;
+
+const Pre = styled.pre`
+  font-family: monospace;
+  font-size: 10px;
+`;
+
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null, errorInfo: null };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    mapStackTrace(error.stack, stack => {
+      const message = [
+        error.toString(),
+        ...stack,
+        "---",
+        error.toString(),
+        errorInfo.componentStack
+      ].join("\n");
+      this.setState({ message });
+    });
+  }
+
+  render() {
+    const { message, copied } = this.state;
+
+    if (message) {
+      return (
+        <Container>
+          <h2>Something went wrong 😢</h2>
+          <p>
+            Please let us know about this error. If you did it already, reload
+            the page, thanks!
+          </p>
+
+          <Details>
+            <details>
+              <Pre>{message}</Pre>
+            </details>
+          </Details>
+
+          <CopyToClipboard
+            text={message}
+            onCopy={() => this.setState({ copied: true })}
+          >
+            <Button>Copy to clipboard</Button>
+          </CopyToClipboard>
+          {copied && <p>Copied!</p>}
+        </Container>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import i18n from "./i18n";
 import { I18nextProvider } from "react-i18next";
 import { ThemeProvider } from "rimble-ui";
+import ErrorBoundary from "./components/ErrorBoundary";
 import theme from "./theme";
 
 
@@ -14,7 +15,9 @@ ReactDOM.render(
   <ThemeProvider theme={theme} style={{ height: '100%' }}>
     <I18nextProvider i18n={i18n}>
       <Router>
-        <App />
+        <ErrorBoundary>
+          <App />
+        </ErrorBoundary>
       </Router>
     </I18nextProvider>
   </ThemeProvider>,


### PR DESCRIPTION
Fix #91

It looks like this:
![signal-attachment-2019-09-06-165515_002](https://user-images.githubusercontent.com/134680/64437812-466b0980-d0c7-11e9-9a82-1d73c8f09bc6.jpeg)

If you open details, you'll see the actual stacktrace... :tada: SOURCEMAPPED :tada:

![signal-attachment-2019-09-06-165515_001](https://user-images.githubusercontent.com/134680/64437821-4b2fbd80-d0c7-11e9-9bbb-b74fcbd71eef.jpeg)

I see the sourcemap is served also in production, so everything should work as expected.

The call to action for the error is "let us know" and "copy to clipboard". If you have better ideas for it please tell me.