### PR TITLE
fix: show human-readable message when no balance card

### DIFF
--- a/src/volt/components/VoteControls/index.js
+++ b/src/volt/components/VoteControls/index.js
@@ -135,6 +135,9 @@ class VoteControls extends Component {
     // Balance Card
     const { BALANCE_CARD_COLOR } = voltConfig;
     const balanceCards = await getUTXOs(plasma, address, BALANCE_CARD_COLOR);
+    if (!balanceCards.length) {
+      throw new Error('No balance card. Please, contact administrator');
+    }
     const balanceCard = balanceCards[0];
 
     return {


### PR DESCRIPTION
Resolves #73

![image](https://user-images.githubusercontent.com/163447/64466508-bf438300-d112-11e9-90c8-def8f34d1ca4.png)
